### PR TITLE
Restrict build CI  on push events 

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -1,7 +1,7 @@
 name: Building
 
 on:
-  push:
+  push: [ main ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
..otherwise the CI is duplicated on PRs (once for the push event and once for the PR event)