### PR TITLE
Bump pyMOR images

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -54,7 +54,9 @@ jobs:
         container: ${{ matrix.container }}
     - name: build
       run: |
-         command="cd /src/mor-coupling && \
+         command="apt update -q && \
+                  apt install -yq libgsl-dev libarpack2-dev liblapack-dev libmuparser-dev libmetis-dev libtbb-dev && \
+                  cd /src/mor-coupling && \
                   cmake . && \
                   make";
 


### PR DESCRIPTION
BUmps CI images from the pyMOR side to the newest 
debian bullseye-based stack
