### PR TITLE
Simplify models for stationary problems

### DIFF
--- a/example/dirichlet-fenics/heat.py
+++ b/example/dirichlet-fenics/heat.py
@@ -1,9 +1,9 @@
 """
 Heat equation with Dirichlet conditions. (Dirichlet problem)
-  u'= Laplace(u) + f  in the unit square [0,1] x [0,1]
+  Laplace(u) = -f     in the unit square [0,1] x [0,1]
   u = u_C             on the coupling boundary at x = 1
-  u = u_D = 3.5       at x = 0
-  u = u_0 = 3         at t = 0
+  u = u_D = 3         at x = 0
+  u = u_0 = 1.5       at t = 0
   f = 0
 """
 
@@ -45,7 +45,7 @@ parser.add_argument("-e", "--error-tol", help="set error tolerance", type=float,
 
 args = parser.parse_args()
 
-fenics_dt = .1  # time step size
+fenics_dt = 1  # time step size
 # Error is bounded by coupling accuracy. In theory we would obtain the analytical solution.
 error_tol = args.error_tol
 
@@ -63,7 +63,7 @@ V_g = VectorFunctionSpace(mesh, 'P', 1)
 W = V_g.sub(0).collapse()
 
 # Define boundary conditions
-u_D = Expression('3', degree=2, alpha=alpha, beta=beta, t=0)
+u_D = Expression('1.5', degree=2, alpha=alpha, beta=beta, t=0)
 u_D_function = interpolate(u_D, V)
 
 # Define flux in x direction
@@ -87,9 +87,9 @@ dt.assign(np.min([fenics_dt, precice_dt]))
 u = TrialFunction(V)
 v = TestFunction(V)
 f = Expression('0', degree=2, alpha=alpha, beta=beta, t=0)
-F = u * v / dt * dx + dot(grad(u), grad(v)) * dx - (u_n / dt + f) * v * dx
+F = dot(grad(u), grad(v)) * dx -  f * v * dx
 
-bcs = [DirichletBC(V, Expression('3.5', degree=2, alpha=alpha, beta=beta, t=0), remaining_boundary)]
+bcs = [DirichletBC(V, Expression('3', degree=2, alpha=alpha, beta=beta, t=0), remaining_boundary)]
 
 # Set boundary conditions at coupling interface once wrt to the coupling
 # expression

--- a/example/neumann-reduced/heat_equation_reduced.py
+++ b/example/neumann-reduced/heat_equation_reduced.py
@@ -73,7 +73,7 @@ class PreciceCoupler:
 
     def advance(self, coupling_input):
         rhs = coupling_input.zeros()
-        dealii.assemble_rhs(self._coupling_data, coupling_input._list[0].impl, rhs._list[0].impl)
+        dealii.assemble_rhs(self._coupling_data, rhs._list[0].impl)
         dealii.advance(coupling_input._list[0].impl, self._coupling_data)
         return rhs
 

--- a/example/neumann-reduced/heat_equation_reduced.py
+++ b/example/neumann-reduced/heat_equation_reduced.py
@@ -67,14 +67,14 @@ class StationaryPreciceModel(Model):
 
 class PreciceCoupler:
 
-    def __init__(self, initial_coupling_input):
-        self._coupling_data = initial_coupling_input.zeros()._list[0].impl
-        dealii.initialize_precice(initial_coupling_input._list[0].impl, self._coupling_data)
+    def __init__(self, initial_coupling_output):
+        self._coupling_data = initial_coupling_output.zeros()._list[0].impl
+        dealii.initialize_precice(initial_coupling_output._list[0].impl, self._coupling_data)
 
-    def advance(self, coupling_input):
-        rhs = coupling_input.zeros()
+    def advance(self, coupling_output):
+        rhs = coupling_output.zeros()
         dealii.assemble_rhs(self._coupling_data, rhs._list[0].impl)
-        dealii.advance(coupling_input._list[0].impl, self._coupling_data)
+        dealii.advance(coupling_output._list[0].impl, self._coupling_data)
         return rhs
 
 

--- a/example/neumann-reduced/parameters.prm
+++ b/example/neumann-reduced/parameters.prm
@@ -4,7 +4,7 @@
 
 subsection Time
   # End time
-  set End time              = 3
+  set End time              = 1
 
   # Time step size
   set Time step size        = 1

--- a/example/neumann-reduced/parameters.prm
+++ b/example/neumann-reduced/parameters.prm
@@ -4,10 +4,10 @@
 
 subsection Time
   # End time
-  set End time              = 1
+  set End time              = 3
 
   # Time step size
-  set Time step size        = 0.1
+  set Time step size        = 1
 
   # Write results every x timesteps
   set Output interval       = 1

--- a/example/precice-config.xml
+++ b/example/precice-config.xml
@@ -49,17 +49,23 @@
 
     <m2n:sockets from="Dirichlet" to="Neumann" exchange-directory=".." />
 
-    <coupling-scheme:serial-explicit>
-      <participants first="Neumann" second="Dirichlet" />
+    <coupling-scheme:serial-implicit>
+      <participants first="Dirichlet" second="Neumann" />
       <max-time value="1.0" />
-      <time-window-size value="0.1" />
-      <exchange data="Heat-Flux" mesh="Dirichlet-Mesh" from="Dirichlet" to="Neumann"/>
+      <max-iterations value="100" />
+      <time-window-size value="1" />
+      <relative-convergence-measure limit="1e-5" data="Heat-Flux" mesh="Dirichlet-Mesh" />
+      <relative-convergence-measure limit="1e-5" data="Temperature" mesh="Neumann-Mesh" />
+      <exchange data="Heat-Flux" mesh="Dirichlet-Mesh" from="Dirichlet" to="Neumann" />
       <exchange
         data="Temperature"
         mesh="Neumann-Mesh"
         from="Neumann"
         to="Dirichlet"
         initialize="false" />
-    </coupling-scheme:serial-explicit>
+      <acceleration:constant>
+        <relaxation value="0.4" />
+      </acceleration:constant>
+    </coupling-scheme:serial-implicit>
   </solver-interface>
 </precice-configuration>


### PR DESCRIPTION
That's at least part one of our simplifications.

Both solver solve now a stationary Laplace problem (the system RHS is really zero). In order to make it solvable, I added for the deal.II participant homogeneous Dirichlet boundary conditions along the right boundary. The Fenics participant has inhomogeneous Dirichlet boundary conditions `u_D=3` along the left boundary. The result of the whole system is now an exceedingly boring 'straight line' between the left and right boundary leading to an interface value of 1.5.

Coupling-wise, I switched now to an implicit coupling and we perform a single time step. The big advantage of this approach is that we can use the acceleration schemes of preCICE and we can measure convergence of our coupling. For the current setup, I applied a simple constant underrelaxation (acceleration). The whole simulation could in theory be accelerated by setting the `initialize=true` (i.e. sending initial data to the Dirichlet participants) in the data exchange, but I think performing a bit more iterations might be a good idea in order to collect information for the reduction.

Ignoring the zero RHS contributions for the moment, I'm still not sure if the integration of the coupling data (first interpolation from DoFs to quadrature points, second numerical integration) on the deal.II side is linear so that we can separate it. If not, we could (must) perform the integration on the FeniCs side and map data conservative so that nothing happens any more when we receive the coupling data.