### PR TITLE
Move assemble rhs

### DIFF
--- a/example/neumann-reduced/heat_equation_reduced.py
+++ b/example/neumann-reduced/heat_equation_reduced.py
@@ -68,6 +68,8 @@ class StationaryPreciceModel(Model):
 
 class CouplingInputOperator(Operator):
 
+    linear = True
+
     def __init__(self, space):
         self.source = self.range = self.space = space
 

--- a/example/neumann-reduced/heat_equation_reduced.py
+++ b/example/neumann-reduced/heat_equation_reduced.py
@@ -135,11 +135,10 @@ else:
 solution = model.solution_space.empty()
 while dealii.is_coupling_ongoing():
     # Compute the solution of the time step
-    new_coupling_input = coupler.advance(coupling_output)
     data = model.compute(solution=True, coupling_input=coupling_input)
-    coupling_input = new_coupling_input
     solution.append(data['solution'])
     coupling_output = data['coupling_output']
+    coupling_input = coupler.advance(coupling_output)
 
 
 # Output the solution to VTK

--- a/lib/heat_equation.cc
+++ b/lib/heat_equation.cc
@@ -83,6 +83,9 @@ namespace Heat_Transfer
     is_coupling_ongoing() const;
 
     void
+    set_initial_condition(Vector<double> &solution_);
+
+    void
     initialize_precice(Vector<double> &solution_,
                        Vector<double> &coupling_data_);
 
@@ -266,14 +269,22 @@ namespace Heat_Transfer
     return adapter.precice.isCouplingOngoing();
   }
 
+
+  template <int dim>
+  void
+  HeatEquation<dim>::set_initial_condition(Vector<double> &solution_)
+  {
+    AnalyticSolution<dim> initial_condition(alpha, beta);
+    initial_condition.set_time(0);
+    VectorTools::interpolate(dof_handler, initial_condition, solution_);
+  }
+
+
   template <int dim>
   void
   HeatEquation<dim>::initialize_precice(Vector<double> &solution_,
                                         Vector<double> &coupling_data_)
   {
-    AnalyticSolution<dim> initial_condition(alpha, beta);
-    initial_condition.set_time(0);
-    VectorTools::interpolate(dof_handler, initial_condition, solution_);
     coupling_data_ = 0;
     output_results(solution_, 0);
 

--- a/lib/py_heat_equation.cc
+++ b/lib/py_heat_equation.cc
@@ -40,6 +40,7 @@ PYBIND11_MODULE(dealii_heat_equation, m)
     .def("get_coupling_data",
          &HeatEquation<2>::get_coupling_data,
          py::return_value_policy::reference_internal)
+    .def("set_initial_condition", &HeatEquation<2>::set_initial_condition)
     .def("initialize_precice", &HeatEquation<2>::initialize_precice)
     .def("output_results", &HeatEquation<2>::output_results)
     .def("assemble_rhs", &HeatEquation<2>::assemble_rhs)


### PR DESCRIPTION
- The first commit takes care of moving the rhs assembly code into the `coupling_input_operator`. Along the way, I have also moved the setting of the initial condition from `initialize_precice` to a dedicated method.

- In the second commit I have altered the communication order in a way which is simpler and makes more sense to me. Of course, this is no longer mathematically equivalent to the original code, so please check if the change is reasonable.

- I am wondering whether we should remove the setting of an inital approximation to further simplify things. 