### PR TITLE
Add coefficient for matrix assembly

### DIFF
--- a/example/neumann-reduced/heat_equation_reduced.py
+++ b/example/neumann-reduced/heat_equation_reduced.py
@@ -104,9 +104,9 @@ class PreciceCoupler:
 # instantiate deal.II model and print some information
 dealii = HeatExample(parameter_file="parameters.prm")
 # Create the grid
-dealii.make_grid()
+dealii.make_grid_and_sparsity_pattern()
 # setup the system, i.e., matrices etc.
-matrix = dealii.setup_system(1, 2, 1.5, 0.5)
+matrix = dealii.create_system_matrix(1, 2, 1.5, 0.5)
 
 # Create full-order model
 operator = DealIIMatrixOperator(matrix)

--- a/example/neumann-reduced/heat_equation_reduced.py
+++ b/example/neumann-reduced/heat_equation_reduced.py
@@ -106,7 +106,7 @@ dealii = HeatExample(parameter_file="parameters.prm")
 # Create the grid
 dealii.make_grid()
 # setup the system, i.e., matrices etc.
-dealii.setup_system(1)
+dealii.setup_system(1, 2, 1.5, 0.5)
 
 # Create full-order model
 operator = DealIIMatrixOperator(dealii.stationary_matrix())

--- a/example/neumann-reduced/heat_equation_reduced.py
+++ b/example/neumann-reduced/heat_equation_reduced.py
@@ -106,7 +106,7 @@ dealii = HeatExample(parameter_file="parameters.prm")
 # Create the grid
 dealii.make_grid()
 # setup the system, i.e., matrices etc.
-dealii.setup_system()
+dealii.setup_system(1)
 
 # Create full-order model
 operator = DealIIMatrixOperator(dealii.stationary_matrix())

--- a/example/neumann-reduced/heat_equation_reduced.py
+++ b/example/neumann-reduced/heat_equation_reduced.py
@@ -106,10 +106,10 @@ dealii = HeatExample(parameter_file="parameters.prm")
 # Create the grid
 dealii.make_grid()
 # setup the system, i.e., matrices etc.
-dealii.setup_system(1, 2, 1.5, 0.5)
+matrix = dealii.setup_system(1, 2, 1.5, 0.5)
 
 # Create full-order model
-operator = DealIIMatrixOperator(dealii.stationary_matrix())
+operator = DealIIMatrixOperator(matrix)
 coupling_input_operator = CouplingInputOperator(operator.source)
 fom = StationaryPreciceModel(operator, coupling_input_operator=coupling_input_operator)
 

--- a/lib/heat_equation.cc
+++ b/lib/heat_equation.cc
@@ -50,7 +50,7 @@ namespace Heat_Transfer
     make_grid();
 
     void
-    setup_system();
+    setup_system(double coefficient_value);
 
     void
     assemble_rhs(const Vector<double> &heat_flux_, Vector<double> &rhs_);
@@ -273,7 +273,7 @@ namespace Heat_Transfer
 
   template <int dim>
   void
-  HeatEquation<dim>::setup_system()
+  HeatEquation<dim>::setup_system(double coefficient_value)
   {
     dof_handler.distribute_dofs(fe);
 
@@ -297,9 +297,11 @@ namespace Heat_Transfer
     sparsity_pattern.copy_from(dsp);
     stationary_system_matrix_.reinit(sparsity_pattern);
 
+    const Functions::ConstantFunction<dim> coefficient(coefficient_value);
     MatrixCreator::create_laplace_matrix(dof_handler,
                                          QGauss<dim>(fe.degree + 1),
-                                         stationary_system_matrix_);
+                                         stationary_system_matrix_,
+                                         &coefficient);
 
     solution.reinit(dof_handler.n_dofs());
     system_rhs.reinit(dof_handler.n_dofs());

--- a/lib/heat_equation.cc
+++ b/lib/heat_equation.cc
@@ -49,7 +49,7 @@ namespace Heat_Transfer
     void
     make_grid();
 
-    void
+    SparseMatrix<double>
     setup_system(double coefficient1,
                  double coefficient2,
                  double threshold_x,
@@ -313,7 +313,7 @@ namespace Heat_Transfer
   }
 
   template <int dim>
-  void
+  SparseMatrix<double>
   HeatEquation<dim>::setup_system(double coefficient1,
                                   double coefficient2,
                                   double threshold_x,
@@ -379,6 +379,10 @@ namespace Heat_Transfer
                                          solution,
                                          system_rhs);
     }
+    SparseMatrix<double> matrix;
+    matrix.reinit(sparsity_pattern);
+    matrix.copy_from(stationary_system_matrix_);
+    return matrix;
   }
 
 

--- a/lib/py_heat_equation.cc
+++ b/lib/py_heat_equation.cc
@@ -25,7 +25,7 @@ PYBIND11_MODULE(dealii_heat_equation, m)
     .def(py::init<const std::string &>(),
          py::arg("parameter_file") = std::string("parameters"))
     .def("make_grid", &HeatEquation<2>::make_grid)
-    .def("setup_system", &HeatEquation<2>::setup_system)
+    .def("setup_system", &HeatEquation<2>::setup_system, py::arg("coefficient"))
     .def("advance", &HeatEquation<2>::advance)
     .def("stationary_matrix",
          &HeatEquation<2>::stationary_system_matrix,

--- a/lib/py_heat_equation.cc
+++ b/lib/py_heat_equation.cc
@@ -25,7 +25,12 @@ PYBIND11_MODULE(dealii_heat_equation, m)
     .def(py::init<const std::string &>(),
          py::arg("parameter_file") = std::string("parameters"))
     .def("make_grid", &HeatEquation<2>::make_grid)
-    .def("setup_system", &HeatEquation<2>::setup_system, py::arg("coefficient"))
+    .def("setup_system",
+         &HeatEquation<2>::setup_system,
+         py::arg("coefficient1"),
+         py::arg("coefficient2"),
+         py::arg("threshold_x"),
+         py::arg("threshold_y"))
     .def("advance", &HeatEquation<2>::advance)
     .def("stationary_matrix",
          &HeatEquation<2>::stationary_system_matrix,

--- a/lib/py_heat_equation.cc
+++ b/lib/py_heat_equation.cc
@@ -30,7 +30,8 @@ PYBIND11_MODULE(dealii_heat_equation, m)
          py::arg("coefficient1"),
          py::arg("coefficient2"),
          py::arg("threshold_x"),
-         py::arg("threshold_y"))
+         py::arg("threshold_y"),
+         py::return_value_policy::move)
     .def("advance", &HeatEquation<2>::advance)
     .def("stationary_matrix",
          &HeatEquation<2>::stationary_system_matrix,

--- a/lib/py_heat_equation.cc
+++ b/lib/py_heat_equation.cc
@@ -24,18 +24,16 @@ PYBIND11_MODULE(dealii_heat_equation, m)
   py::class_<HeatEquation<2>>(m, "HeatExample")
     .def(py::init<const std::string &>(),
          py::arg("parameter_file") = std::string("parameters"))
-    .def("make_grid", &HeatEquation<2>::make_grid)
-    .def("setup_system",
-         &HeatEquation<2>::setup_system,
+    .def("make_grid_and_sparsity_pattern",
+         &HeatEquation<2>::make_grid_and_sparsity_pattern)
+    .def("create_system_matrix",
+         &HeatEquation<2>::create_system_matrix,
          py::arg("coefficient1"),
          py::arg("coefficient2"),
          py::arg("threshold_x"),
          py::arg("threshold_y"),
          py::return_value_policy::move)
     .def("advance", &HeatEquation<2>::advance)
-    .def("stationary_matrix",
-         &HeatEquation<2>::stationary_system_matrix,
-         py::return_value_policy::reference_internal)
     .def("set_initial_condition", &HeatEquation<2>::set_initial_condition)
     .def("initialize_precice", &HeatEquation<2>::initialize_precice)
     .def("output_results", &HeatEquation<2>::output_results)


### PR DESCRIPTION
... as discussed. The change is rather simple as deal.II has predefined functionality to handle the coefficient.

Follow-up question is where the function should store the assembled matrix. At the moment, the content is always stored in the `stationary_system_matrix_`, i.e., calling `setup_system(coeff)` multiple times will override previous content of the matrix. If we want to keep the content of the matrix we either need to copy it on the python side before re-assembling the matrix for a different coefficient or we need to handle things different on the deal.II side. @sdrave any opinion on this?

Regarding the handling of Dirichlet boundary conditions in deal.II, their [documentation](https://dealii.org/developer/doxygen/deal.II/namespaceMatrixTools.html) (excerpt of the section 'Global elimination') writes: 

>  For this reason, we perform a very simple line balancing by not setting the main diagonal entry to unity, but rather to the value it had before deleting this line, or to the first nonzero main diagonal entry if it is zero for some reason. Of course we have to change the right hand side appropriately.

Thus, the column and row of the constrained DoF have only one non-zero entry  (the value of the unconstrained system) and the coupling towards other DoFs is resolved using Gauss elimination. 