### PR TITLE
Add reset functionality for preCICE

### DIFF
--- a/example/neumann-reduced/heat_equation_reduced.py
+++ b/example/neumann-reduced/heat_equation_reduced.py
@@ -154,6 +154,10 @@ while dealii.is_coupling_ongoing():
     coupling_input = coupler.advance(coupling_output)
 toc = perf_counter()
 
+# Reset preCICE and rerun the simulation
+# dealii.reset_precice()
+# coupler = PreciceCoupler(fom.solution_space)
+# coupling_input = coupler.init(coupling_output)
 
 # Output the solution to VTK
 if USE_ROM:

--- a/lib/py_heat_equation.cc
+++ b/lib/py_heat_equation.cc
@@ -36,6 +36,7 @@ PYBIND11_MODULE(dealii_heat_equation, m)
     .def("advance", &HeatEquation<2>::advance)
     .def("set_initial_condition", &HeatEquation<2>::set_initial_condition)
     .def("initialize_precice", &HeatEquation<2>::initialize_precice)
+    .def("reset_precice", &HeatEquation<2>::reset_precice)
     .def("output_results", &HeatEquation<2>::output_results)
     .def("assemble_rhs", &HeatEquation<2>::assemble_rhs)
     .def("is_coupling_ongoing", &HeatEquation<2>::is_coupling_ongoing);


### PR DESCRIPTION
I added the reset now for the `deal.II` side and it works, but I need to restart the fenics side again. I'm not sure if that's a problem and how exactly the final loop is supposed to look like. @sdrave any opinions?